### PR TITLE
Imported mermaid's default theme scss into index.js to display tooltip

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import 'mermaid/src/themes/default/index.scss'
 import 'antd/dist/antd.css'
 import '@fortawesome/fontawesome-free-webfonts/css/fa-brands.css'
 import '@fortawesome/fontawesome-free-webfonts/css/fa-regular.css'


### PR DESCRIPTION
This is based on Issue https://github.com/knsv/mermaid/issues/682
If this is the correct way to get tooltip to appear, I will update the docs to recommend importing the scss and also clarify how one can define their own callback function.

Currently the tooltip display at the bottom of the page even if it's out of the visible window. The issue seems to be that `.mermaidTooltip` is not picking up the styling defined in `flowchart.scss`. This PR imports `default/index.scss` so that the tooltip will appear as expected.

![mermaid-tooltip](https://user-images.githubusercontent.com/3513997/43142654-e5acc95e-8f26-11e8-82e9-0e3cf72b66f4.gif)
