### PR TITLE
Make textarea font family monospace for more accessible editing

### DIFF
--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -56,11 +56,11 @@ class Edit extends React.Component {
         <Col span={8}>
           <Affix>
             <Card title='Code'>
-              <Input.TextArea autosize={{ minRows: 4, maxRows: 16 }} value={this.json.code} onChange={this.onCodeChange} />
+              <Input.TextArea style={{fontFamily: 'monospace'}} autosize={{ minRows: 4, maxRows: 16 }} value={this.json.code} onChange={this.onCodeChange} />
             </Card>
           </Affix>
           <Card title='Mermaid configuration'>
-            <Input.TextArea autosize={{ minRows: 4, maxRows: 16 }} defaultValue={JSON.stringify(this.json.mermaid, null, 2)} onChange={this.onMermaidConfigChange} />
+            <Input.TextArea style={{fontFamily: 'monospace'}} autosize={{ minRows: 4, maxRows: 16 }} defaultValue={JSON.stringify(this.json.mermaid, null, 2)} onChange={this.onMermaidConfigChange} />
           </Card>
           <Card title='Links'>
             <ul className='marketing-links'>


### PR DESCRIPTION
This made it a lot easier to use the live editor as with monospacing columns line up nicely.